### PR TITLE
Include query string for private repos

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -45,7 +45,7 @@ module.exports = {
                 }
             });
 
-            request(rootUrl + req.path, {headers: headers}).on('response', function (gh) {
+            request(rootUrl + req.path, {qs: req.query, headers: headers}).on('response', function (gh) {
                 var status = gh.statusCode;
                 if (status < 200 || status > 399) {
                     // Treat as a 404.


### PR DESCRIPTION
Didn't see this discussed anywhere, apologies if I missed it.

Perhaps this was left out because of security concerns, in which case I might add a note to the homepage with brief instructions for forking and hosting on one's own for this specific purpose.

Let me know if you'd prefer this implemented with query string args whitelisted similar to `relayRequestHeaders`.

Cheers and thanks for the project.
