### PR TITLE
added X-Content-Type-Options as reason why browsers don't execute some JS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
         </p>
 
         <p>
-        Too bad! Most things served from <code>raw.github.com</code> have a <code>text/plain</code> content type, which means HTML won't render, and some browsers won't execute JavaScript or apply CSS.
+        Too bad! Most things served from <code>raw.github.com</code> have a <code>text/plain</code> content type and send out the <code>X-Content-Type-Options</code> header with the value <code>nosniff</code>, which means HTML won't render, and some browsers won't execute JavaScript or apply CSS.
         </p>
 
         <h2>The Solution</h2>


### PR DESCRIPTION
`<script src="https://raw.github.com/user/repo/master/filename.js">` would load if GitHub didn't send out X-Content-Type-Options on the `raw.github.com` domain.
(ref: https://code.google.com/p/chromium/issues/detail?id=180007)
