### PR TITLE
Add .swf to extensionWhitelist

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -25,6 +25,7 @@ var extensionWhitelist = {
      '.js'  : true,
      '.rss' : true,
      '.svg' : true,
+     '.swf' : true,
      '.xml' : true
 };
 


### PR DESCRIPTION
I have a `.swf` demo on http://zeroclipboard.org/ that uses rawgithub for testing latest changes. It would be great if we could have `.swf` in the whitelist.

cc @JamesMGreene
