### PR TITLE
Adding webfonts to proxied file extensions

### DIFF
--- a/conf/index.js
+++ b/conf/index.js
@@ -15,8 +15,14 @@ module.exports = {
         '.rss'   : true,
         '.svg'   : true,
         '.swf'   : true,
-        '.xml'   : true
+        '.xml'   : true,
+        '.ttf'   : true,
+        '.ttc'   : true,
+        '.eot'   : true,
+        '.otf'   : true,
+        '.woff'  : true
     },
+
 
     // Public directory containing static files.
     publicDir: require('fs').realpathSync(__dirname + '/../public'),


### PR DESCRIPTION
Webfonts won't be rendered without a matching `Acces-Control-Allow-Origin` header. `raw.github.com` will serve these with `Access-Control-Allow-Origin: https://render.github.com`, so we can't redirect font requests.

This is breaking FontAwesome. See an example of this breakage in https://rawgithub.com/sapo/Ink/develop/dist/documentation/icons.html#nav-web
