### PR TITLE
Updating domain for Gists

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,7 +41,7 @@
         <pre class="after">https://<strong>rawgithub.com</strong>/user/repo/master/filename.js</pre>
 
         <p>
-        It works with gists too! Just replace <code>gist.github.com</code> with <code>rawgithub.com</code> in the raw gist URL.
+        It works with gists too! Just replace <code>gist.githubusercontent.com</code> with <code>rawgithub.com</code> in the raw gist URL.
         </p>
 
         <h2>The Caveat</h2>

--- a/web.js
+++ b/web.js
@@ -42,12 +42,14 @@ app.get('*/google[0-9a-f]{16}.html',
     middleware.error403);
 
 // Public or private gist.
+// Gist raw domain changed on 2014-02-21:
+// http://developer.github.com/changes/2014-02-21-gist-raw-file-url-change/
 app.get(/^\/[0-9A-Za-z-]+\/[0-9a-f]+\/raw\//,
     middleware.stats,
     middleware.blacklist,
     middleware.noRobots,
-    middleware.fileRedirect('https://gist.github.com'),
-    middleware.proxyPath('https://gist.github.com'));
+    middleware.fileRedirect('https://gist.githubusercontent.com'),
+    middleware.proxyPath('https://gist.githubusercontent.com'));
 
 // Repo file.
 app.get('/:user/:repo/:branch/*',


### PR DESCRIPTION
GitHub has [changed the domain for serving raw gists](http://developer.github.com/changes/2014-02-21-gist-raw-file-url-change/) from _gist.github.com_ to _gist.githubusercontent.com_, so rawgithub.com now 404s on these URLs.

This patch fixes this.
