### PR TITLE
Add .appcache mime to use of offline webapps

### DIFF
--- a/conf/index.js
+++ b/conf/index.js
@@ -26,6 +26,7 @@ module.exports = {
     // Requests to the cdnDomain will bypass this whitelist and proxy all file
     // types.
     extensionWhitelist: {
+        '.appcache': true,
         '.coffee': true,
         '.css'   : true,
         '.eot'   : true,


### PR DESCRIPTION
It is not tested, but may be it will allow to get files ending with `.appcache` to be served as `text/cache-manifest`.
