### PR TITLE
Issue #71 - Don't allow release Urls

### DIFF
--- a/public/js/url-formatter.js
+++ b/public/js/url-formatter.js
@@ -5,7 +5,7 @@
 
 var REGEX_GIST_URL = /^(https?):\/\/gist\.github(?:usercontent)?\.com\/(.+?\/[0-9a-f]+\/raw\/(?:[0-9a-f]+\/)?.+\..+)$/i;
 var REGEX_RAW_URL  = /^(https?):\/\/raw\.github(?:usercontent)?\.com\/([^\/]+\/[^\/]+\/[^\/]+|[0-9A-Za-z-]+\/[0-9a-f]+\/raw)\/(.+\..+)/i;
-var REGEX_REPO_URL = /^(https?):\/\/github\.com\/(.+?)\/(.+?)\/(?:(?:blob|raw)\/)?(.+?\/.+)/i;
+var REGEX_REPO_URL = /^(https?):\/\/github\.com\/(.[^\/]+?)\/(.[^\/]+?)\/(?!releases\/)(?:(?:blob|raw)\/)?(.+?\/.+)/i;
 
 var devEl  = doc.getElementById('url-dev');
 var prodEl = doc.getElementById('url-prod');


### PR DESCRIPTION
Issue #71 
The following regex enhancement stops release Urls from green-lighting in the UI.

Testing:
- Ive run the existing tests just in case!
- Otherwise Ive opted for manual testing (I don't know enough about the tech used to write reasonable tests Im afraid).  I've heavily used this site for testing, as well as the rawgit site itself: [regex101.com](https://regex101.com/#javascript).

I haven't changed the other regexes as it doesn't make sense to do so (I think... you can't have releases in either of them can you?!).

Let me know if you have any questions!
Usman