### PR TITLE
add OpenSearch support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ app.use(express.static(config.publicDir));
 
 // -- Routes -------------------------------------------------------------------
 app.get('/', (req, res) => {
-  res.render('index', {includeMetaDescription: true});
+  res.render('index', {includeMetaDescription: true, url: req.query.url});
 });
 
 app.get('/faq', (req, res) => {

--- a/public/js/url-formatter.js
+++ b/public/js/url-formatter.js
@@ -20,7 +20,10 @@
     prodCopyButton.style.display = 'inline-block';
   }
 
-  urlEl.addEventListener('input', function () {
+  urlEl.addEventListener('input', formatURL, false);
+  formatURL();
+
+  function formatURL () {
     var url = urlEl.value.trim();
 
     if (REGEX_RAW_URL.test(url)) {
@@ -77,7 +80,7 @@
       devCopyButton.disabled  = true;
       prodCopyButton.disabled = true;
     }
-  }, false);
+  }
 
   devEl.addEventListener('focus', onFocus);
   prodEl.addEventListener('focus', onFocus);

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>RawGit</ShortName>
+  <Description>GitHub URL</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon"></Image>
+  <Url type="text/html" method="get" template="https://rawgit.com/?url={searchTerms}"/>
+  <moz:SearchForm>https://rawgit.com</moz:SearchForm>
+</OpenSearchDescription>

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -6,7 +6,8 @@
   <div class="url-paste">
     <p id="url-form">
       <label for="url" class="offscreen">GitHub URL:</label>
-      <input id="url" class="url" type="url" placeholder="Paste a GitHub file or gist URL here." autofocus>
+      <input id="url" class="url" type="url" value="{{url}}"
+             placeholder="Paste a GitHub file or gist URL here." autofocus>
     </p>
   </div>
 

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -2,6 +2,7 @@
 <html lang="en">
 <meta charset="utf-8">
 <title>{{#if title}}{{title}} - RawGit{{else}}RawGit{{/if}}</title>
+<link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="RawGit">
 <meta name="viewport" content="width=device-width">
 
 {{#if includeMetaDescription}}


### PR DESCRIPTION
There's nothing to be searched here, but that may help when people want to quickly use the browser URL bar to paste GitHub URLs and get RawGit URLs back.

I have implemented OpenSearch support many times with this exact same template and it works. Just haven't tested if the OpenSearch functionality works in this specific case (probably because my local server isn't being accepted by Google Chrome as a potential OpenSearch target), but, unless browsers detect we are pasting an URL and block that, it should work well.