### PR TITLE
Call out that gists URLs must link to the raw (not default) view.

### DIFF
--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -7,7 +7,7 @@
     <p id="url-form">
       <label for="url" class="offscreen">GitHub URL:</label>
       <input id="url" class="url" type="url" value="{{url}}"
-             placeholder="Paste a GitHub file or gist URL here." autofocus>
+             placeholder="Paste a GitHub file or gist URL (don't forget to use the `raw` link!) here." autofocus>
     </p>
   </div>
 


### PR DESCRIPTION
I couldn't figure out why a gist wasn't working for a while...til I found the admonition to use the raw gist over yonder in that there FAQ. It'd be nice to put the advisement in-context.