### PR TITLE
Add raw.githack.com to the list of alternatives

### DIFF
--- a/views/news/sunset.handlebars
+++ b/views/news/sunset.handlebars
@@ -15,6 +15,7 @@
 
     <ul>
       <li><a href="https://www.jsdelivr.com/rawgit">jsDelivr</a></li>
+      <li><a href="https://raw.githack.com/">raw.githack.com</a></li>
       <li><a href="https://pages.github.com/">GitHub Pages</a></li>
       <li><a href="https://codesandbox.io/">CodeSandbox</a></li>
       <li><a href="https://unpkg.com/">unpkg</a></li>


### PR DESCRIPTION
raw.githack.com was initially inspired by and for a long period of time tried to mimic RawGit. 
Could it try to be one of the official alternatives as the last tribute to RawGit?